### PR TITLE
feat: using a new proxy server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,15 @@ import { query } from '@ifyour/deeplx'
 
 const app = new Hono()
 
+// Proxy server to resolve error 525, see: https://github.com/cloudflare/workerd/issues/776
+const proxyEndpoint = 'https://cors.mingming.dev/https://www2.deepl.com/jsonrpc'
+
 app
   .get('/', (c) => c.redirect('/translate'))
   .get('/translate', (c) => c.text('Please use POST method :)'))
   .post('/translate', async (c) => {
     const params = await c.req.json().catch(() => ({}))
-    const result = await query(params, { proxyEndpoint: 'https://ideepl.vercel.app/jsonrpc' })
+    const result = await query(params, { proxyEndpoint })
     return c.json(result, result.code)
   })
 


### PR DESCRIPTION
Since the proxy server previously deployed at Vercel has reached the free package critical request limit, I am now using my personal proxy service.
This proxy service uses the open source solution [Rob--W/cors-anywhere](https://github.com/Rob--W/cors-anywhere).
If you don't trust this proxy server, you can deploy it yourself. Enjoy!